### PR TITLE
chore: use NEXT_PUBLIC_VERCEL_URL instead  of VERCEL_URL

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -18,8 +18,8 @@ function App({
 
 export default withTRPC<AppRouter>({
   config({ ctx }) {
-    const url = process.env.VERCEL_URL
-      ? `https://${process.env.VERCEL_URL}/api/trpc`
+    const url = process.env.NEXT_PUBLIC_VERCEL_URL
+      ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}/api/trpc`
       : 'http://localhost:3000/api/trpc';
 
     return {


### PR DESCRIPTION
The env variable VERCEL_URL is only available on the server side. That's why the API URL is wrong when running the app (`http://localhost:3000/api/trpc/send-answer?batch=1`). In order to use this variable on the client side (browser), we need to use the prefix NEXT_PUBLIC.